### PR TITLE
Updates custom commands for emulators and adds commands for simulators

### DIFF
--- a/.changeset/healthy-onions-play.md
+++ b/.changeset/healthy-onions-play.md
@@ -1,0 +1,9 @@
+---
+"dotfiles": minor
+---
+
+Adds custom zsh scripts for Mitmproxy, Emulators, and Simulators
+
+- Adds an oh-my-zsh/custom/simulator.zsh
+- Adds an oh-my-zsh/custom/mitm.zsh to start/stop mitmproxy
+- Minor tweaks to oh-my-zsh/custom/emulator.zsh

--- a/oh-my-zsh/custom/emulator.zsh
+++ b/oh-my-zsh/custom/emulator.zsh
@@ -24,10 +24,12 @@ function start_emulator() {
     # This option clears the data for the virtual device and returns it to the same state as when it was first defined. 
     # All installed apps and settings are removed
   # -no-snapshot - Disables the Quick Boot feature completely and doesn't load or save the emulator state.
+  # -tcpdump - dumps tcp log file for tools like Wireshark.
   emulator \
     -avd $AVD \
     -wipe-data \
-    -no-snapshot
+    -no-snapshot \
+    -tcpdump emulator.tcpdump.log
 }
 
 # Start emulator as writable to install cert
@@ -66,9 +68,12 @@ function start_emulator_as_writable() {
 
 function install_apk() {
   apk=$1
-  [[ -f $apk ]] || echo "Couldn't find $apk" && exit 1;
-  echo "Installing $apk..."
-  adb install $1
+  if [[ ! -f $apk ]]; then 
+    echo "Couldn't find $apk"
+  else
+    echo "Installing $apk..."
+    adb install $1
+  fi
 }
 
 function _disable_secure_boot_verification() {

--- a/oh-my-zsh/custom/mitm.zsh
+++ b/oh-my-zsh/custom/mitm.zsh
@@ -1,0 +1,29 @@
+#!/bin/zsh
+
+# Points the macOS network interfaces to the locally-running proxy.
+function enable_macos_proxy() {
+  interfaces="$(networksetup -listallnetworkservices | tail +2)" 
+
+  IFS=$'\n' # split on newlines in the for loops
+
+  for interface in $interfaces; do
+    echo "Setting proxy on $interface"
+    networksetup -setwebproxy "$interface" 127.0.0.1 8080
+    networksetup -setwebproxystate "$interface" on
+    networksetup -setsecurewebproxy "$interface" 127.0.0.1 8080
+    networksetup -setsecurewebproxystate "$interface" on
+  done
+}
+
+# Resets the network interfaces to disable proxying.
+function disable_macos_proxy() {
+  interfaces="$(networksetup -listallnetworkservices | tail +2)" 
+
+  IFS=$'\n' # split on newlines in the for loops
+  for interface in $interfaces; do
+    echo "Disabling proxy on $interface"
+    networksetup -setwebproxystate "$interface" off
+    networksetup -setsecurewebproxystate "$interface" off
+  done
+}
+

--- a/oh-my-zsh/custom/simulator.zsh
+++ b/oh-my-zsh/custom/simulator.zsh
@@ -1,0 +1,54 @@
+#!/bin/zsh
+
+# Lists the available iOS Simulators
+function list_simulators() {
+  xcrun simctl list devices available
+}
+
+# List booted apps
+function list_booted_apps() {
+  xcrun simctl listapps booted | grep CFBundleIdentifier
+}
+
+# Starts the specified iOS Simulator, by UDID
+#
+# param $1: The UDID of the iOS Simulator
+#  - e.g., 5EA9227B-3DCA-48DB-A773-A0314EE30EE7
+function start_simulator() {
+  simulator_id=$1
+  validate_udid $simulator_id
+  echo "Starting simulator $simulator_id..."
+  xcrun simctl boot ${simulator_id}
+}
+
+# Stops the specified iOS Simulator, by UDID
+#
+# param $1: The UDID of the iOS Simulator
+#  - e.g., 5EA9227B-3DCA-48DB-A773-A0314EE30EE7
+function stop_simulator() {
+  simulator_id=$1
+  validate_udid $simulator_id
+  echo "Stopping simulator $simulator_id..."
+  xcrun simctl shutdown ${simulator_id}
+}
+
+
+# Restarts the specified iOS Simulator, by UDID
+#
+# param $1: The UDID of the iOS Simulator
+#  - e.g., 5EA9227B-3DCA-48DB-A773-A0314EE30EE7
+function restart_simulator() {
+  simulator_id=$1
+  validate_udid $simulator_id
+  echo "Restarting Simulator $simulator_id... "
+  stop_simulator $simulator_id
+  start_simulator $simulator_id
+}
+
+# Install the .app onto the booted simulator
+#
+# param $1: Path to .app
+function install_app() {
+  path_to_app=$1
+  xcrun simctl install booted $path_to_app
+}


### PR DESCRIPTION
Adds custom zsh scripts for Mitmproxy, Emulators, and Simulators

- Adds an oh-my-zsh/custom/simulator.zsh
- Adds an oh-my-zsh/custom/mitm.zsh to start/stop mitmproxy
- Minor tweaks to oh-my-zsh/custom/emulator.zsh