### PR TITLE
Semi-working - Updates for neovim 0.11 and lsp config

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -501,15 +501,17 @@ mason_lspconfig.setup {
   ensure_installed = vim.tbl_keys(servers),
 }
 
-mason_lspconfig.setup_handlers {
-  function(server_name)
-    require('lspconfig')[server_name].setup {
-      capabilities = capabilities,
-      on_attach = on_attach,
-      settings = servers[server_name],
-    }
-  end,
-}
+-- mason_lspconfig.setup_handlers {
+--   function(server_name)
+--     vim.lsp.config(server_name, {
+--     -- require('lspconfig')[server_name].setup {
+--       capabilities = capabilities,
+--       on_attach = on_attach,
+--       settings = servers[server_name],
+--     })
+--   end,
+-- }
+
 
 -- nvim-cmp setup
 local cmp = require 'cmp'

--- a/config/nvim/lua/plugins/dashboard-nvim.lua
+++ b/config/nvim/lua/plugins/dashboard-nvim.lua
@@ -1,3 +1,16 @@
+-- Function to grab the hostname of the machine.
+local _M = {}
+function _M.getHostname()
+    local f = io.popen("/bin/hostname")
+    if not f then
+        return ""
+    end
+    local hostname = f:read("*a") or ""
+    f:close()
+    hostname = string.gsub(hostname, "\n$", "")
+    return hostname
+end
+
 return {
   'nvimdev/dashboard-nvim',
   event = 'VimEnter',
@@ -9,6 +22,20 @@ return {
         week_header = {
           enable = true,
         },
+        footer =
+          function()
+            if _M.getHostname() == 'MAC-JRAMOS' then
+              return {
+              '',
+              '  GoodRx - Joel Ramos'
+            }
+            else
+              return {
+                '',
+                '  Personal - Joel Ramos'
+              }
+            end
+          end,
         shortcut = {
           { desc = '󰊳 Update', group = '@property', action = 'Lazy update', key = 'u' },
           {
@@ -20,15 +47,21 @@ return {
             key = 'f',
           },
           {
-            desc = ' Apps',
-            group = 'DiagnosticHint',
-            action = 'Telescope app',
+            desc = ' Singularity',
+            group = 'DashboardShortCut',
+            action = 'cd ~/GoodRx/singularity',
             key = 'a',
+          },
+          {
+            desc = ' Maestro',
+            group = 'DashboardShortCut',
+            action = 'cd ~/GoodRx/maestro-e2e-tests',
+            key = 'm',
           },
           {
             desc = ' dotfiles',
             group = 'Number',
-            action = 'Telescope dotfiles',
+            action = 'cd ~/.dotfiles',
             key = 'd',
           },
         },


### PR DESCRIPTION
mason-lspconfig has dropped features since neovim 0.11+ since evidently `vim.lsp.config` now provides them.

This commit just gets neovim to stop breaking/complaining, but causes me to lose a bunch of features that were added via mason-lspconfig and the `on_attach` function. I will have to figure out how to add those back via `vim.lsp.config`