### PR TITLE
chore: updates lazygit config to allow rewording local commits with gpg signage

### DIFF
--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,6 +1,9 @@
 # See https://sourcegraph.com/github.com/jesseduffield/lazygit/-/blob/docs/Config.md#configuring-lazygit
 # for the complete documentation/schema for this file.
 
+git:
+  overrideGpg: true
+
 os:
   # Make sure lazygit opens files for editing in Neovim.
   # LazyGit *should* figure out your editor based on the $VISUAL or $EDITOR 


### PR DESCRIPTION
## Description

Updates config/lazygit/config.yml to set `overrideGpg` to `true`.